### PR TITLE
Fixed Elementor upgrade past v2.8.0, change to Schemes\Color fixes bug preventing widgets from loading in editor.

### DIFF
--- a/widgets/three_boxes_widget.php
+++ b/widgets/three_boxes_widget.php
@@ -3,7 +3,7 @@ namespace CIOOS\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Scheme_color;
+use Elementor\Core\Schemes;
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
@@ -83,8 +83,8 @@ class Three_Boxes_Widget extends \Elementor\Widget_Base {
                 'label' => __( 'Background Color', 'cioos-siooc-wordpress-plugin'),
                 'type' => Controls_Manager::COLOR,
                 'scheme' => [
-					'type' => Scheme_color::get_type(),
-					'value' => Scheme_color::COLOR_1,
+					'type' => Schemes\Color::get_type(),
+					'value' => Schemes\Color::COLOR_1,
                 ],
 			]
         );


### PR DESCRIPTION
We just upgraded the free Elementor plugin from v2.7.5 (Aug/Sept) to v2.8.2, this initially broke the website home page unless the CIOOS plugin was temporarily disabled, or if downgrading to an older version of Elementor. I noticed in v2.8.0 they updated a reference to color. Luckily WordPress caught this fatal error in the error.log file, and it was an easy fix. Once we updated to the newest version of the CIOOS WordPress plugin that helped with one of the fatal errors on the home page, but the next step was getting the Elementor editor to load the entire widgets menu (blocking error: stuck on the spinning load animation). Fixing the colour namespace and updating a few lines of code worked it all out.